### PR TITLE
71 bug deleting a habit crashes the app

### DIFF
--- a/app/(tabs)/home/index.tsx
+++ b/app/(tabs)/home/index.tsx
@@ -28,6 +28,8 @@ import api from "@/utils/api";
 import AISuggestionSkeleton from "@/utils/components/specific/AISuggestionSkeleton";
 import {
   getDate,
+  getDateFromFormattedDate,
+  getDateMinusNDays,
   getFormattedDate,
   getFormattedDatesThisWeek,
   relationBetweenTodayAndDate,
@@ -38,6 +40,9 @@ import React from "react";
 import { Ionicons } from "@expo/vector-icons";
 
 export default function Index() {
+  // mmkvStorage.set("appStartDate", "2025-7-25");
+  console.log("Stay up bada eyyooooo", mmkvStorage.getString("appStartDate"));
+
   const [proActiveMessage, setProActiveMessage] = useState<string | null>(null); // will eventually fetch it's last value from a key-value store so that the user doesn't have to stare at the "loading" for 1-3 seconds
   const [proActiveMessageHeight, setProActiveMessageHeight] =
     useState<number>(76); // 76 because it is the height of the skeleton (60 height + 16 margin)
@@ -195,8 +200,31 @@ export default function Index() {
             </Text>
             <View style={styles.jumpToDayContainer}>
               <TouchableOpacity
-                style={styles.jumpToDayButton}
                 onPress={handleDateBack}
+                // makes the button disabled if the user just started their app
+                // so that they cannot view days that are before when they started
+                disabled={
+                  getDateMinusNDays(
+                    -1,
+                    getDateFromFormattedDate(
+                      mmkvStorage.getString("appStartDate")!
+                    )
+                  ) > habitsDate
+                }
+                style={[
+                  styles.jumpToDayButton,
+                  {
+                    opacity:
+                      getDateMinusNDays(
+                        -1,
+                        getDateFromFormattedDate(
+                          mmkvStorage.getString("appStartDate")!
+                        )
+                      ) > habitsDate
+                        ? 0.5
+                        : 1,
+                  },
+                ]}
               >
                 <Ionicons
                   name="chevron-back-outline"

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "habitmentor-ai",
   "main": "expo-router/entry",
   "version": "1.4.1",
+  "private": true,
   "scripts": {
     "start": "expo start --dev-client",
     "reset-project": "node ./scripts/reset-project.js",
@@ -83,6 +84,5 @@
     "postinstall-postinstall": "^2.1.0",
     "react-native-codegen": "^0.70.7",
     "typescript": "~5.8.3"
-  },
-  "private": true
+  }
 }

--- a/utils/components/specific/AddNewHabitModal.tsx
+++ b/utils/components/specific/AddNewHabitModal.tsx
@@ -125,7 +125,10 @@ export default function AddNewHabitModal({
                     // adding points + id to the habit
                     const newHabit = { ...values };
 
-                    if (newHabit && newHabit.frequency) {
+                    if (newHabit) {
+                      if (!newHabit.frequency) {
+                        newHabit.frequency = Array(7).fill(true); // default value when the user doesn't touch the frequency at all
+                      }
                       // if the frequency property exists within that habit item:
                       // seeing how many days the user is doing that particular habit:
                       const daysHabitIsActive = newHabit.frequency.reduce(

--- a/utils/components/specific/zeego/EditHabitDropdownMenu.tsx
+++ b/utils/components/specific/zeego/EditHabitDropdownMenu.tsx
@@ -54,9 +54,9 @@ export default function EdithabitDropdownMenu({
                 {
                   text: "Yes",
                   onPress: () => {
-                    // habit deltion logic here
-                    SheetManager.hide("example-sheet");
-                    deleteHabit(habitId);
+                    SheetManager.hide("example-sheet").then(() => {
+                      deleteHabit(habitId);
+                    });
                   },
                 },
               ],

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -15,6 +15,12 @@ export const getDate = function () {
   // return tomorrow;
 };
 
+export const getDateMinusNDays = (daysOffset: number, date?: Date) => {
+  const baseDate = date ? new Date(date) : getDate();
+  baseDate.setDate(baseDate.getDate() - daysOffset);
+  return baseDate;
+};
+
 export const getWeekdayNumber = function (date?: Date) {
   if (date) {
     return date.getDay();


### PR DESCRIPTION
- make it so that the habit is deleted AFTER the action sheet is fully closed by leveraging chaining promise
- QOL Change: Make it so that the user cannot go 1 day back if that is the day when the user did not start the app (in simpler terms
- closes #71 